### PR TITLE
Databases IAM policy hotfix

### DIFF
--- a/permissions-reference.adoc
+++ b/permissions-reference.adoc
@@ -2306,7 +2306,7 @@ a|
 
 As permissions are added and removed, we'll note them in the sections below.
 
-=== 1 February 2025
+=== 1 February 2026
 
 The following permissions were added to the Storage workload: 
 

--- a/permissions-reference.adoc
+++ b/permissions-reference.adoc
@@ -610,32 +610,42 @@ Select your operational mode to view the required IAM policies:
 --
 [source,json]
 ----
-[
+{
+  "Version": "2012-10-17",
+  "Statement": [
     {
-        "Sid": "FSxRemediation",
-        "Effect": "Allow",
-        "Action": [
-            "fsx:UpdateFileSystem",
-            "fsx:UpdateVolume"
-        ],
-        "Resource": "*"
+      "Sid": "FSxRemediation",
+      "Effect": "Allow",
+      "Action": [
+        "fsx:UpdateFileSystem",
+        "fsx:UpdateVolume"
+      ],
+      "Resource": "*"
     },
     {
-        "Sid": "EC2Remediation",
-        "Effect": "Allow",
-        "Action": [
-            "ec2:StartInstances",
-            "ec2:ModifyInstanceAttribute",
-            "ec2:StopInstances"
-        ],
-        "Resource": "*",
-        "Condition": {
-            "StringLike": {
-                "ec2:ResourceTag/aws:cloudformation:stack-name": "WLMDB*"
-            }
+      "Sid": "EC2Remediation",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:StartInstances",
+        "ec2:ModifyInstanceAttribute",
+        "ec2:StopInstances"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringLike": {
+          "ec2:ResourceTag/aws:cloudformation:stack-name": "WLMDB*"
         }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "iam:SimulatePrincipalPolicy"
+      ],
+      "Resource": "*"
     }
-]
+  ]
+}
 ----
 --
 .Database host creation


### PR DESCRIPTION
This pull request updates the IAM policy documentation in `permissions-reference.adoc` to include the missing header with the version and statement in the operations and remediation permission policy.