### PR TITLE
link-capitalization-fix

### DIFF
--- a/learn-custom-dashboards.adoc
+++ b/learn-custom-dashboards.adoc
@@ -47,7 +47,7 @@ link:add-credentials.html[Learn how to add AWS credentials and set up IAM permis
 
 === Link to FSx for ONTAP
 
-Workload Factory requires a Link to connect to FSx for ONTAP file systems. A Link creates a trust relationship and connectivity between Workload Factory and one or more FSx for ONTAP file systems. This enables you to monitor and manage certain file system features directly from the ONTAP REST API calls that are not available through the Amazon FSx for ONTAP API.
+Workload Factory requires a link to connect to FSx for ONTAP file systems. A link creates a trust relationship and connectivity between Workload Factory and one or more FSx for ONTAP file systems. This enables you to monitor and manage certain file system features directly from the ONTAP REST API calls that are not available through the Amazon FSx for ONTAP API.
 
 https://docs.netapp.com/us-en/workload-fsx-ontap/create-link.html[Learn how to create a link^].
 

--- a/workload-factory-overview.adoc
+++ b/workload-factory-overview.adoc
@@ -97,7 +97,7 @@ You don't need a link to get started with Workload Factory, but in some cases yo
 
 Links currently leverage AWS Lambda.
 
-https://docs.netapp.com/us-en/workload-fsx-ontap/links-overview.html[Learn more about Links^]
+https://docs.netapp.com/us-en/workload-fsx-ontap/links-overview.html[Learn more about links^]
 
 === Codebox automation
 


### PR DESCRIPTION
This pull request makes minor improvements to documentation for consistency and clarity. The changes standardize the capitalization of "link" when referring to the feature that connects Workload Factory to FSx for ONTAP file systems.

- Standardization of terminology:
  * Updated references to "Link" to "link" for consistency in `learn-custom-dashboards.adoc` and `workload-factory-overview.adoc`. [[1]](diffhunk://#diff-772e631bd19319d709a19bf2a65545ade9fd8b10e037b9a20c85d64cf5198f19L50-R50) [[2]](diffhunk://#diff-27f8b32e8c0fd5be6d2831fbda30f006ab5582ac9bf97359454a073e01378f87L100-R100)