### PR TITLE
Update add credentials steps

### DIFF
--- a/_include/well-architected-workloads.adoc
+++ b/_include/well-architected-workloads.adoc
@@ -8,10 +8,6 @@ You can dismiss the analysis of configurations that do not apply to your environ
 
 You can also create custom rules in plain language to validate your environments against your organization's standards and NetApp best practices. Test rules with a dry run, then schedule them to run across your environments. link:https://docs.netapp.com/us-en/console-well-architected/learn-custom-rules.html[Learn more about custom rules^].
 
-You can also create custom rules in plain language to validate your environments against your organization's standards and NetApp best practices. Test rules with a dry run, then schedule them to run across your environments.
-
-link:https://docs.netapp.com/us-en/console-well-architected/learn-custom-rules.html[Learn more about custom rules^].
-
 == Why it matters
 
 Workload Factory applies best practices to large storage, database, and VMware environments by combining ongoing assessment with recommendation insights and remediation. Automated fixes applied in the Workload Factory console reduce human error, ensure uniform management, and preserve performance and reliability across your workload infrastructures.

--- a/add-credentials.adoc
+++ b/add-credentials.adoc
@@ -69,7 +69,7 @@ You'll need to have credentials to log in to your AWS account.
 . Log in to the https://console.workloads.netapp.com/[Workload Factory console^].
 . From the menu, select *Administration* and then *Credentials*.
 . On the Credentials page, select *Add credentials*.
-. On the Add credentials page, select *Add manually* and then use the following steps to complete each section under _Permissions configuration_.
+. On the Add Credentials page, select *Add manually* and then use the following steps to complete each section under _Permissions configuration_.
 +
 image:screenshot-add-credentials-manually.png[A screenshot showing the items that you need to define manually for each set of credentials.]
 
@@ -109,15 +109,15 @@ image:screenshot-create-role.png[A screenshot showing which permissions will be 
 
 .Steps
 
-. On the Workload Factory Add Credentials page, under *Permissions configuration*, open the *Create role* section.
+. From the Add Credentials page in Workload Factory, expand *Create role* under *Permissions configuration*.
 
-. Copy the JSON snippet by selecting the *JSON code* link.
+. Select *JSON code* to copy the policy.
 
 . In the AWS Management Console, select *Roles > Create Role*.
 
 . Under *Trusted entity type*, select *Custom Trust Policy*.
 
-. Replace the current content in the text box with the JSON snippet that you copied in step 2.
+. Replace the current content in the text box with the JSON code that you copied in step 2.
 
 . Select *Next*.
 

--- a/add-credentials.adoc
+++ b/add-credentials.adoc
@@ -109,12 +109,15 @@ image:screenshot-create-role.png[A screenshot showing which permissions will be 
 
 .Steps
 
+. On the Workload Factory Add Credentials page, under *Permissions configuration*, open the *Create role* section.
+
+. Copy the JSON snippet by selecting the *JSON code* link.
+
 . In the AWS Management Console, select *Roles > Create Role*.
 
-. Under *Trusted entity type*, select *AWS account*.
+. Under *Trusted entity type*, select *Custom Trust Policy*.
 
-.. Select *Another AWS account* and copy and paste the account ID for FSx for ONTAP workload management from the Workload Factory UI.
-.. Select *Required external ID* and copy and paste the external ID from the Workload Factory UI.
+. Replace the current content in the text box with the JSON snippet that you copied in step 2.
 
 . Select *Next*.
 
@@ -124,7 +127,7 @@ image:screenshot-create-role.png[A screenshot showing which permissions will be 
 
 . Copy the Role ARN.
 
-. Return to the Add Credentials page in Workload Factory, expand the *Create role* section under *Permission configuration*, and paste the ARN in the _Role ARN_ field.
+. Return to the Add Credentials page in Workload Factory and then paste the role ARN in the _Role ARN_ field.
 
 === Step 3: Enter a name and add the credentials
 


### PR DESCRIPTION
Includes the revisions from this GitHub issue #95. 

This pull request improves the clarity and accuracy of the documentation for adding credentials and creating roles in AWS for the Workload Factory console. The changes update instructions, screenshots, and terminology to better match the current UI and AWS workflows, and remove redundant content.
